### PR TITLE
add setting for . autocompletion, limit scope to prolog/logtalk files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "logtalk-for-vscode",
     "displayName": "Logtalk for VSCode",
     "description": "Logtalk programming support",
-    "version": "0.23.0",
+    "version": "0.23.1",
     "publisher": "LogtalkDotOrg",
     "icon": "images/logtalk.png",
     "license": "MIT",
@@ -389,6 +389,11 @@
                 "logtalk.enableCodeLens": {
                     "type": "boolean",
                     "description": "Enables testing results code lens.",
+                    "default": true
+                },
+                "logtalk.completion.recursive.enabled": {
+                    "type": "boolean",
+                    "description": "Enables auto-complete recursive parameter. Disable to leave the dot alone (reload required).",
                     "default": true
                 }
             }

--- a/src/features/editHelpers.ts
+++ b/src/features/editHelpers.ts
@@ -3,7 +3,7 @@
 import {
   /* CommentRule, OnEnterRule, */
   Disposable, IndentAction, languages,
-  Position, Range, Selection, 
+  Position, Range, Selection,
   TextDocument, window, workspace
 } from "vscode";
 
@@ -137,11 +137,19 @@ export function loadEditHelpers(subscriptions: Disposable[]) {
     });
     return match[1] + "(" + newList.join(", ") + ")";
   }
-  
+
+  let recursiveCompletion = workspace.getConfiguration("logtalk").get<boolean>("completion.recursive.enabled", true);
+
   workspace.onDidChangeTextDocument(
     e => {
+      if (!recursiveCompletion) {
+        return;
+      }
       let lastChange = e.contentChanges[0];
       if (lastChange === undefined) {
+        return;
+      }
+      if (!['logtalk', 'prolog'].includes(e.document.languageId)) {
         return;
       }
       let lastChar = lastChange.text;


### PR DESCRIPTION
* Auto-completion for standalone period can now be disabled via settings
* Scope of autocompletion is limited to Logtalk/Prolog files, to reduce interference with other files

Not the most elegant fix but it fixes LogtalkDotOrg/logtalk-for-vscode#9